### PR TITLE
chore: add metatag description

### DIFF
--- a/src/components/astro/Head.astro
+++ b/src/components/astro/Head.astro
@@ -25,6 +25,7 @@ const { title, metaTags } = site;
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 <link rel="icon" href={favicon.src} type="image/png">
 <meta name="generator" content={Astro.generator} />
+<meta name="description" content={metaTags.description} />
 
 <!-- Open Graph tags -->
 <meta property="og:title" content={metaTags.og.title} />

--- a/src/data/siteMetaData.ts
+++ b/src/data/siteMetaData.ts
@@ -3,6 +3,7 @@ import type { SiteMetaData } from '../types';
 export const site: SiteMetaData = {
   title: 'Emanoel Lopes | emanoellopes.dev',
   metaTags: {
+    description: 'Emanoel Lopes | Meu site pessoal onde de vez em quando escrevo sobre assuntos técnicos relacionados ao mundo do desenvolvimento frontend.',
     og: {
       title: 'Emanoel Lopes | emanoellopes.dev',
       type: 'website',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -31,6 +31,7 @@ export interface SocialPlatforms {
 export type SiteMetaData = {
   title: string;
   metaTags: {
+    description: string;
     og: {
       title: string;
       type: string;


### PR DESCRIPTION
I totally forgot to implement metatag description and Lighthouse show me:

<img width="1916" height="726" alt="lighthouse-score" src="https://github.com/user-attachments/assets/6aaeaec4-1f48-436e-a25d-92fd8322b7fa" />
